### PR TITLE
Add executing scripts before

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   install_extensions:
     description: 'Install Sphinx extensions listed in $source_dir/requirements.txt'
     default: true
+  script_before:
+    description: 'Script to execute before compiling the documentation'
+    default: ''
 outputs:
   name:
     description: 'Author name'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,8 +108,10 @@ if [ "$INPUT_INSTALL_EXTENSIONS" = true ] ; then
 fi
 
 # execute a script before compiling
-chmod +x $INPUT_SCRIPT_BEFORE
-./$INPUT_SCRIPT_BEFORE
+if [ -z "$INPUT_CREATE_README" ] ; then
+    chmod +x $INPUT_SCRIPT_BEFORE
+    ./$INPUT_SCRIPT_BEFORE
+fi
 
 # sphinx-build
 echo ::group::Sphinx build html

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,6 +107,10 @@ if [ "$INPUT_INSTALL_EXTENSIONS" = true ] ; then
     echo ::endgroup::
 fi
 
+# execute a script before compiling
+chmod +x $INPUT_SCRIPT_BEFORE
+./$INPUT_SCRIPT_BEFORE
+
 # sphinx-build
 echo ::group::Sphinx build html
 echo "sphinx-build -b html $docs_src/$INPUT_SOURCE_DIR $docs_html -E -d $sphinx_doctree"


### PR DESCRIPTION
I propose to add an option to execute a script before building the documentation. this enables pull other repositories of build doxygen XML from the code to put it together with the docs.

Maybe after script would be also useful.

what do you think?

Cheers,
Denis