### PR TITLE
Adding double quotes for git config user.name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -93,8 +93,8 @@ fi
 
 # git config
 echo ::group::Set commiter
-echo "git config user.name $author_name"
-git config user.name $author_name
+echo "git config user.name \"$author_name\""
+git config user.name "$author_name"
 echo "git config user.email $author_email"
 git config user.email $author_email
 echo ::endgroup::


### PR DESCRIPTION
This avoids problems with user.name that have more than one surname, like mine. Example here: https://github.com/biocorecrg/SIB_course_nextflow_Nov_2021/runs/4198201357?check_suite_focus=true